### PR TITLE
pipelines: add shared pipeline jobs

### DIFF
--- a/Jenkinsfile.branch
+++ b/Jenkinsfile.branch
@@ -1,0 +1,10 @@
+// Load a library dynamically. For more detail, see:
+// https://jenkins.io/doc/book/pipeline/shared-libraries/#defining-declarative-pipelines
+library identifier: 'crossplane-cicd@master', retriever: modernSCM(
+  [$class: 'GitSCMSource',
+   remote: 'https://github.com/crossplane/cicd',
+   credentialsId: 'github-upbound-jenkins'])
+
+// This is the name of a file declared in vars/{{fileName}}.groovy in the library repository.
+// It configures a whole declarative pipeline for us.
+runStackBranchPipeline()

--- a/Jenkinsfile.continuous
+++ b/Jenkinsfile.continuous
@@ -1,0 +1,10 @@
+// Load a library dynamically. For more detail, see:
+// https://jenkins.io/doc/book/pipeline/shared-libraries/#defining-declarative-pipelines
+library identifier: 'crossplane-cicd@master', retriever: modernSCM(
+  [$class: 'GitSCMSource',
+   remote: 'https://github.com/crossplane/cicd',
+   credentialsId: 'github-upbound-jenkins'])
+
+// This is the name of a file declared in vars/{{fileName}}.groovy in the library repository.
+// It configures a whole declarative pipeline for us.
+runStackContinuousPipeline()

--- a/Jenkinsfile.publish
+++ b/Jenkinsfile.publish
@@ -1,0 +1,10 @@
+// Load a library dynamically. For more detail, see:
+// https://jenkins.io/doc/book/pipeline/shared-libraries/#defining-declarative-pipelines
+library identifier: 'crossplane-cicd@master', retriever: modernSCM(
+  [$class: 'GitSCMSource',
+   remote: 'https://github.com/crossplane/cicd',
+   credentialsId: 'github-upbound-jenkins'])
+
+// This is the name of a file declared in vars/{{fileName}}.groovy in the library repository.
+// It configures a whole declarative pipeline for us.
+runStackPublishPipeline()

--- a/Jenkinsfile.tag
+++ b/Jenkinsfile.tag
@@ -1,0 +1,10 @@
+// Load a library dynamically. For more detail, see:
+// https://jenkins.io/doc/book/pipeline/shared-libraries/#defining-declarative-pipelines
+library identifier: 'crossplane-cicd@master', retriever: modernSCM(
+  [$class: 'GitSCMSource',
+   remote: 'https://github.com/crossplane/cicd',
+   credentialsId: 'github-upbound-jenkins'])
+
+// This is the name of a file declared in vars/{{fileName}}.groovy in the library repository.
+// It configures a whole declarative pipeline for us.
+runStackTagPipeline()


### PR DESCRIPTION
Related to crossplane/crossplane#1235

We have a set of common stack jobs in a shared repo. This adds
initial Jenkinsfiles which point to those so that we can get build and
publish pipeline functionality.

## Testing

The functionality for each individual job has been tested with the other projects that use them. The code sharing has been tested in [this job execution](https://jenkinsci.upbound.io/job/crossplane/job/stack-minimal-gcp/job/branch-create/job/test-submodule-build/5/console)

## Other work

* [x] A webhook between this repo and the upbound Jenkins needs to be configured
* [x] The jobs on Jenkins need to be created (by copying existing ones from sample-stack-wordpress and renaming them)
* [ ] Document the release process