### PR TITLE
behavior image: remove explicit image

### DIFF
--- a/.registry/behavior.yaml
+++ b/.registry/behavior.yaml
@@ -1,5 +1,4 @@
 source:
-  image: crossplane/stack-minimal-aws:v0.2.1
   path: "kustomize"
 crd:
   kind: MinimalAWS


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane!

We strongly recommend you look through our contributor guide at https://git.io/fj2m9
if this is your first time opening a Crossplane pull request. You can find us in
https://slack.crossplane.io/messages/dev if you need any help contributing.
-->

### Description of your changes
<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

Fixes #
-->
Related to crossplane/crossplane#1308

To make it easier to manage the version of a behavior image, we now
support injecting the envelope image name into the behavior image
source field. Since we use the same image for both, this makes it easier
to always use the same version for both.

Note that this change is not backward-compatible, and requires 
Crossplane version `v0.8.0-rc.82.g2d90198` or later.

### Testing

Tested locally with the latest version of crossplane with the `stack-minimal-gcp` stack. The `StackDefinition` object, the `Stack` object, and the `Deployment` used the correct image name and tag for the behavior image.

