### PR TITLE
iam: use v1beta1 iam resources of AWS provider

### DIFF
--- a/kustomize/aws/identity/iamrole.yaml
+++ b/kustomize/aws/identity/iamrole.yaml
@@ -1,23 +1,23 @@
-apiVersion: identity.aws.crossplane.io/v1alpha3
+apiVersion: identity.aws.crossplane.io/v1beta1
 kind: IAMRole
 metadata:
   name: iamrole
 spec:
-  roleName: iamrole
-  description: placeholder_for_description
-  assumeRolePolicyDocument: |
-    {
-      "Version": "2012-10-17",
-      "Statement": [
-        {
-          "Effect": "Allow",
-          "Principal": {
-            "Service": "eks.amazonaws.com"
-          },
-          "Action": "sts:AssumeRole"
-        }
-      ]
-    }
+  forProvider:
+    description: placeholder_for_description
+    assumeRolePolicyDocument: |
+      {
+        "Version": "2012-10-17",
+        "Statement": [
+          {
+            "Effect": "Allow",
+            "Principal": {
+              "Service": "eks.amazonaws.com"
+            },
+            "Action": "sts:AssumeRole"
+          }
+        ]
+      }
   reclaimPolicy: Delete
   providerRef:
     name: aws-provider

--- a/kustomize/aws/identity/iamrolepolicyattachment.yaml
+++ b/kustomize/aws/identity/iamrolepolicyattachment.yaml
@@ -1,24 +1,26 @@
 ---
-apiVersion: identity.aws.crossplane.io/v1alpha3
+apiVersion: identity.aws.crossplane.io/v1beta1
 kind: IAMRolePolicyAttachment
 metadata:
   name: servicepolicy
 spec:
-  roleNameRef:
-    name: iamrole
-  policyArn: arn:aws:iam::aws:policy/AmazonEKSServicePolicy
+  forProvider:
+    roleNameRef:
+      name: iamrole
+    policyArn: arn:aws:iam::aws:policy/AmazonEKSServicePolicy
   reclaimPolicy: Delete
   providerRef:
     name: aws-provider
 ---
-apiVersion: identity.aws.crossplane.io/v1alpha3
+apiVersion: identity.aws.crossplane.io/v1beta1
 kind: IAMRolePolicyAttachment
 metadata:
   name: clusterpolicy
 spec:
-  roleNameRef:
-    name: iamrole
-  policyArn: arn:aws:iam::aws:policy/AmazonEKSClusterPolicy
+  forProvider:
+    roleNameRef:
+      name: iamrole
+    policyArn: arn:aws:iam::aws:policy/AmazonEKSClusterPolicy
   reclaimPolicy: Delete
   providerRef:
     name: aws-provider

--- a/kustomize/aws/identity/kustomizeconfig.yaml
+++ b/kustomize/aws/identity/kustomizeconfig.yaml
@@ -11,7 +11,5 @@ nameReference:
         kind: IAMRolePolicyAttachment
   - kind: IAMRole
     fieldSpecs:
-      - path: spec/roleName
-        kind: IAMRole
-      - path: spec/roleNameRef
+      - path: spec/forProvider/roleNameRef
         kind: IAMRolePolicyAttachment


### PR DESCRIPTION
Manually tested. This will make minimal-aws compatible with `master` of provider-aws.