### PR TITLE
AWS Sample Stack name everywhere

### DIFF
--- a/.registry/app.yaml
+++ b/.registry/app.yaml
@@ -1,4 +1,4 @@
-title: "Stack AWS Sample"
+title: "AWS Sample Stack"
 readme: |
   A sample stack with built-in network and classes that let you provision
   resources with minimal node requirements in AWS.

--- a/.registry/resources/awssample.resource.yaml
+++ b/.registry/resources/awssample.resource.yaml
@@ -1,11 +1,11 @@
 id: awssample
-title: Stack AWS Sample
-titlePlural: Stack AWS Sample
+title: AWS Sample Stack
+titlePlural: AWS Sample Stacks
 category: Stack
 overviewShort: |
   One click to install resource classes with minimal node requirements that are
   connected to each other in the same network for all AWS resources.
 overview: |
-  You can use Stack AWS Sample to deploy a network and resource classes which
+  You can use AWS Sample Stack to deploy a network and resource classes which
   allow you to deploy resources in that network with minimal node
   configurations.

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-STACK_VERSION ?= v0.2.1
+STACK_VERSION ?= local
 STACK_IMG ?= crossplane/stack-aws-sample:$(STACK_VERSION)
 
 build:


### PR DESCRIPTION
Make new name `AWS Sample Stack` used everywhere to avoid confusion. I also replaced `v0.2.1` with `local` in the Makefile as it's only used for local dev builds and you might override actual `v0.2.1` image in your local with `make`.