### PR TITLE
dbsubnetgroup: update to v1beta1

### DIFF
--- a/kustomize/aws/database/dbsubnetgroup.yaml
+++ b/kustomize/aws/database/dbsubnetgroup.yaml
@@ -1,14 +1,14 @@
-apiVersion: database.aws.crossplane.io/v1alpha3
+apiVersion: database.aws.crossplane.io/v1beta1
 kind: DBSubnetGroup
 metadata:
   name: dbsubnetgroup
 spec:
-  groupName: dbsubnetgroup
-  description: placeholder_for_description
-  subnetIdRefs:
-    - name: subnet-a
-    - name: subnet-b
-    - name: subnet-c
+  forProvider:
+    description: placeholder_for_description
+    subnetIdRefs:
+      - name: subnet-a
+      - name: subnet-b
+      - name: subnet-c
   reclaimPolicy: Delete
   providerRef:
     name: aws-provider

--- a/kustomize/aws/database/kustomizeconfig.yaml
+++ b/kustomize/aws/database/kustomizeconfig.yaml
@@ -13,8 +13,6 @@ nameReference:
         kind: RDSInstanceClass
   - kind: DBSubnetGroup
     fieldSpecs:
-      - path: spec/groupName
-        kind: DBSubnetGroup
       - path: specTemplate/forProvider/dbSubnetGroupNameRef/name
         kind: RDSInstanceClass
   - kind: Provider
@@ -23,5 +21,5 @@ nameReference:
         kind: DBSubnetGroup
   - kind: Subnet
     fieldSpecs:
-      - path: spec/subnetIdRefs/name
+      - path: spec/forProvider/subnetIdRefs/name
         kind: DBSubnetGroup


### PR DESCRIPTION
Update the Subnet CR to accommodate new version introduced in https://github.com/crossplane/provider-aws/pull/162