### PR TITLE
Update crossplaneio links to crossplane

### DIFF
--- a/.registry/app.yaml
+++ b/.registry/app.yaml
@@ -40,7 +40,7 @@ keywords:
  - "default"
  - "private network"
 website: "https://crossplane.io"
-source: "https://github.com/crossplaneio/stack-aws-sample"
+source: "https://github.com/crossplane/stack-aws-sample"
 permissionScope: Cluster
 dependsOn:
   - crd: '*.cache.aws.crossplane.io/v1beta1'

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ You can use this stack to spin up a private network as well as resource classes 
 
 Requirements:
 * Crossplane should be installed.
-* [AWS Provider](https://github.com/crossplaneio/provider-aws) should be installed and its version should be at least 0.7.1
+* [AWS Provider](https://github.com/crossplane/provider-aws) should be installed and its version should be at least 0.7.1
 
 If you have crossplane-cli installed, you can use the following command to install:
 


### PR DESCRIPTION
We are running into redirect issues now with `crossplaneio`. This updates links that depend on it.

Signed-off-by: hasheddan <georgedanielmangum@gmail.com>