### PR TITLE
Delete Provider resource last

### DIFF
--- a/.registry/behavior.yaml
+++ b/.registry/behavior.yaml
@@ -4,7 +4,7 @@ crd:
   kind: AWSSample
   apiVersion: aws.stacks.crossplane.io/v1alpha1
 engine:
-  controllerImage: crossplane/templating-controller:v0.3.0
+  controllerImage: crossplane/templating-controller:v0.3.0-9.gb138971
   type: kustomize
   kustomize:
     overlays:

--- a/kustomize/aws/provider.yaml
+++ b/kustomize/aws/provider.yaml
@@ -2,6 +2,8 @@ apiVersion: aws.crossplane.io/v1alpha3
 kind: Provider
 metadata:
   name: aws-provider
+  annotations:
+    templatestacks.crossplane.io/deletion-priority: "-1"
 spec:
   region: us-central-1
   credentialsSecretRef:


### PR DESCRIPTION
Delete Provider resource last so that others can still use the credentials during their deletion process

Signed-off-by: Muvaffak Onus <onus.muvaffak@gmail.com>